### PR TITLE
Support for Redmine Lightbox Plugin

### DIFF
--- a/lib/issue_note_list/patches/redmine_lightbox_plugin_patch.rb
+++ b/lib/issue_note_list/patches/redmine_lightbox_plugin_patch.rb
@@ -1,0 +1,20 @@
+# Patch for https://github.com/alphanodes/redmine_lightbox
+
+module IssueNoteList
+  module Patches
+    module RedmineLightboxPluginPatch
+      def lightbox_plugins_controllers
+          controllers = super
+          if controllers.exclude? "IssueNoteListController"
+            controllers << "IssueNoteListController"
+          end
+          controllers
+        end
+    end
+  end
+end
+
+if Module.const_defined?("RedmineLightbox")
+  RedmineLightbox.singleton_class.prepend(IssueNoteList::Patches::RedmineLightboxPluginPatch)
+  Rails.logger.info "RedmineLightboxPluginPatch prepended"
+end


### PR DESCRIPTION
The Redmine Lightbox plugin (https://github.com/alphanodes/redmine_lightbox) is now supported.